### PR TITLE
Problem with catalina.properties fixed

### DIFF
--- a/src/main/java/com/googlecode/t7mp/StopMojo.java
+++ b/src/main/java/com/googlecode/t7mp/StopMojo.java
@@ -16,6 +16,16 @@
 
 package com.googlecode.t7mp;
 
+import java.util.ArrayList;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
 import org.apache.catalina.startup.Bootstrap;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -28,7 +38,7 @@ import org.apache.maven.plugin.MojoFailureException;
  *
  */
 public final class StopMojo extends AbstractMojo {
-
+    
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         Bootstrap bootstrap = (Bootstrap) getPluginContext().get(AbstractT7Mojo.T7_BOOTSTRAP_CONTEXT_ID);
@@ -36,8 +46,24 @@ public final class StopMojo extends AbstractMojo {
         if (bootstrap != null) {
             try {
                 bootstrap.stop();
+                cleanupMBeanServer();
             } catch (Exception e) {
                 throw new MojoExecutionException("Error stopping the Tomcat with Bootstrap from Plugin-Context", e);
+            }
+        }
+    }
+
+    /*
+     * On shutdown not all MBean will be unregistered. That causes a problem if the Tomcat must
+     * start more than once in the same VM. The bootstrap.start() breaks.
+     */
+    private void cleanupMBeanServer() throws MalformedObjectNameException,
+            MBeanRegistrationException, InstanceNotFoundException {
+        ArrayList<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
+        for (MBeanServer server : servers) {
+            ObjectName naming = new ObjectName("Catalina:*");
+            for (ObjectInstance object : server.queryMBeans(naming, null)) {
+                server.unregisterMBean(object.getObjectName());
             }
         }
     }


### PR DESCRIPTION
Wenn im config Dir eine catalina.properties vorhanden ist gibt es Probleme wenn da nicht die Werte für http.port, shutdown.port, shutdown.command gesetzt sind. Sind diese Werte gesetzt lassen Sie sich nicht mehr im Plugin überschreiben.

Ich habe einen Merge der beiden config Dateien eingebaut, der sicherstellt das diese 3 Properties nicht von der catalina.properties im config Ordner überschrieben werden.

WiKi Eintrag zum Thema config Files und wie Sie zusammenarbeiten kommt die Tage.
