### PR TITLE
add support for hot deployment of classes

### DIFF
--- a/src/main/java/com/googlecode/t7mp/AbstractT7Mojo.java
+++ b/src/main/java/com/googlecode/t7mp/AbstractT7Mojo.java
@@ -191,6 +191,18 @@ public abstract class AbstractT7Mojo extends AbstractMojo {
      * 
      */
     protected String packaging = "war";
+    
+    /**
+     * 
+     * @parameter expression="${t7.scanClasses}" default-value="false"
+     */
+    protected boolean scanClasses = false;
+
+    /**
+     * @parameter default-value="${basedir}/target/classes"
+     * @readonly
+     */
+    protected File webappClassDirectory;
 
     /**
      * 
@@ -236,6 +248,14 @@ public abstract class AbstractT7Mojo extends AbstractMojo {
 
     public void setLookInside(boolean lookInside) {
         this.lookInside = lookInside;
+    }
+
+    public boolean isScanClasses() {
+        return scanClasses;
+    }
+
+    public void setScanClasses(boolean scanClasses) {
+        this.scanClasses = scanClasses;
     }
 
     public String getTomcatVersion() {

--- a/src/main/java/com/googlecode/t7mp/ModifiedFileTimerTask.java
+++ b/src/main/java/com/googlecode/t7mp/ModifiedFileTimerTask.java
@@ -14,7 +14,8 @@ import com.google.common.collect.Collections2;
 
 public final class ModifiedFileTimerTask extends TimerTask {
 
-    private static final String DEF = "src/main/webapp/";
+    private static final String DEF_STATIC = "src/main/webapp/";
+    private static final String DEF_CLASSES = "target/classes/";
     private long lastrun = System.currentTimeMillis();
     private final File rootDirectory;
     private final File webappDirectory;
@@ -34,9 +35,10 @@ public final class ModifiedFileTimerTask extends TimerTask {
         Collection<File> changedFiles = Collections2.filter(fileSet, Predicates.and(new ModifiedFilePredicate(timeStamp), new FileSuffixPredicate(suffixe)));
         for (File file : changedFiles) {
             String absolutePath = file.getAbsolutePath();
-
-            int endIndex = absolutePath.lastIndexOf("src/main/webapp/");
-            String copyFragment = absolutePath.substring(endIndex + DEF.length());
+            String def = getResourceDef(absolutePath);
+            
+            int endIndex = absolutePath.lastIndexOf(def);
+            String copyFragment = absolutePath.substring(endIndex + def.length());
             File copyToFile = new File(webappDirectory, copyFragment);
             System.out.println("CHANGED: " + absolutePath);
             System.out.println("GOES TO : " + copyToFile.getAbsolutePath());
@@ -48,5 +50,13 @@ public final class ModifiedFileTimerTask extends TimerTask {
             }
         }
         System.out.println("-----------END SCAN-------------");
+    }
+    
+    private String getResourceDef(String absolutePath) {
+        if (absolutePath.lastIndexOf(DEF_STATIC) != -1) {
+            return DEF_STATIC;
+        } else {
+            return DEF_CLASSES;
+        }
     }
 }

--- a/src/main/java/com/googlecode/t7mp/RunMojo.java
+++ b/src/main/java/com/googlecode/t7mp/RunMojo.java
@@ -54,6 +54,15 @@ public class RunMojo extends AbstractT7Mojo {
                 scanner.start();
                 shutdownHook.addScanner(scanner);
             }
+            if (scanClasses) {
+                ScannerConfiguration scannerConfiguration = new ScannerConfiguration();
+                scannerConfiguration.setRootDirectory(webappClassDirectory);
+                scannerConfiguration.setWebappDirectory(new File(catalinaBase, "webapps/" + buildFinalName + "/WEB-INF/classes"));
+                scannerConfiguration.setEndings("%"); // it's all or nothing
+                Scanner scanner = new Scanner(scannerConfiguration, getLog());
+                scanner.start();
+                shutdownHook.addScanner(scanner);
+            }
             if (tomcatSetAwait) {
                 Runtime.getRuntime().addShutdownHook(shutdownHook);
                 bootstrap.setAwait(tomcatSetAwait);

--- a/src/main/java/com/googlecode/t7mp/ScannerConfiguration.java
+++ b/src/main/java/com/googlecode/t7mp/ScannerConfiguration.java
@@ -46,6 +46,9 @@ public class ScannerConfiguration {
     }
 
     public void setEndings(String endings) {
+        if ("%".equals(endings)) {
+            endings = "";
+        }
         this.endings = endings;
     }
 


### PR DESCRIPTION
I have added a new boolean property "scanClasses" which, if set to true in the pom.xml file, creates a new scanner which monitors the changes in /target/classes and deploys them in the classes directory of tomcat. For that to work, the context has to be reloadable (ie. set the reloadable attribute of the tomcat context to true).

The reason for scanning that directory is that the eclipse maven plugin, on every source file save, compiles it too to /target/classes.

Another change I made was to set the '%' character as wildcard for file endings in a scanner configuration - meaning that, if <endings>%</endings>, all files are scanned and deployed. 
