### PR TITLE
Wrong URL to github's SCM Web Interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </licenses>
 
     <scm>
-        <url>https://github.com/t7mp/t7mp.git</url>
+        <url>https://github.com/t7mp/t7mp</url>
         <connection>scm:git:git@github.com:t7mp/t7mp.git</connection>
         <developerConnection>scm:git:git@github.com:t7mp/t7mp.git</developerConnection>
     </scm>


### PR DESCRIPTION
There is a small typo in the SCM URL pointing to https://github.com/t7mp/t7mp.git which results in a 404 error. Instead, it should point to https://github.com/t7mp/t7mp.
